### PR TITLE
Update CVE-2021-25656.json

### DIFF
--- a/cves/2021/25xxx/CVE-2021-25656.json
+++ b/cves/2021/25xxx/CVE-2021-25656.json
@@ -3,7 +3,7 @@
         "cna": {
             "affected": [
                 {
-                    "product": "Product",
+                    "product": "Avaya Aura Experience Portal",
                     "vendor": "Avaya",
                     "versions": [
                         {


### PR DESCRIPTION
Fix error in affected product in CVE-2021-25656.

The correct product comes from the CVE description itself.
