### PR TITLE
fix: remove greaterThanOrEqual property

### DIFF
--- a/cves/2023/5xxx/CVE-2023-5245.json
+++ b/cves/2023/5xxx/CVE-2023-5245.json
@@ -18,7 +18,6 @@
                     "packageName": "ml.combust.mleap.mleap-tensorflow",
                     "versions": [
                         {
-                            "greaterThanOrEqual": "0.18.0",
                             "lessThan": "0.23.1",
                             "status": "affected",
                             "version": "0.18.0",

--- a/cves/2024/34xxx/CVE-2024-34391.json
+++ b/cves/2024/34xxx/CVE-2024-34391.json
@@ -18,7 +18,6 @@
                     "packageName": "libxmljs",
                     "versions": [
                         {
-                            "greaterThanOrEqual": "0",
                             "lessThanOrEqual": "1.0.11",
                             "status": "affected",
                             "version": "0",

--- a/cves/2024/34xxx/CVE-2024-34392.json
+++ b/cves/2024/34xxx/CVE-2024-34392.json
@@ -18,7 +18,6 @@
                     "packageName": "libxmljs",
                     "versions": [
                         {
-                            "greaterThanOrEqual": "0",
                             "lessThanOrEqual": "1.0.11",
                             "status": "affected",
                             "version": "0",

--- a/cves/2024/34xxx/CVE-2024-34393.json
+++ b/cves/2024/34xxx/CVE-2024-34393.json
@@ -18,7 +18,6 @@
                     "packageName": "libxmljs2",
                     "versions": [
                         {
-                            "greaterThanOrEqual": "0",
                             "lessThanOrEqual": "0.33.0",
                             "status": "affected",
                             "version": "0",

--- a/cves/2024/34xxx/CVE-2024-34394.json
+++ b/cves/2024/34xxx/CVE-2024-34394.json
@@ -18,7 +18,6 @@
                     "packageName": "libxmljs2",
                     "versions": [
                         {
-                            "greaterThanOrEqual": "0",
                             "lessThanOrEqual": "0.33.0",
                             "status": "affected",
                             "version": "0",


### PR DESCRIPTION
`greaterThanOrEqual` is not defined in the schema, and `version` is probably preferable for this purpose.
https://github.com/CVEProject/cve-schema/blob/30f59c7de92fbc77bddade302601cb500c66f718/schema/CVE_Record_Format.json#L273-L355