### PR TITLE
fix: use tag: x_refsource_REDHAT instead of x_redhatRef

### DIFF
--- a/cves/2022/3xxx/CVE-2022-3205.json
+++ b/cves/2022/3xxx/CVE-2022-3205.json
@@ -62,7 +62,7 @@
                 {
                     "tags": [
                         "vdb-entry",
-                        "x_redhatRef"
+                        "x_refsource_REDHAT"
                     ],
                     "url": "https://access.redhat.com/security/cve/CVE-2022-3205"
                 },
@@ -70,7 +70,7 @@
                     "name": "RHBZ#2120597",
                     "tags": [
                         "issue-tracking",
-                        "x_redhatRef"
+                        "x_refsource_REDHAT"
                     ],
                     "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2120597"
                 }


### PR DESCRIPTION
The tag `x_redhatRef` seems to be used only for [CVE-2022-3205](https://github.com/CVEProject/cvelistV5/blob/main/cves/2022/3xxx/CVE-2022-3205.json). 
In general, when referring to `access.redhat.com/security/cve/` or `bugzilla.redhat.com/show_bug.cgi?id=`, the tag `x_refsource_REDHAT` seems to be used.