### PR TITLE
Remove unnecessary `.zip` extension from artifact name

### DIFF
--- a/.github/workflows/baseline.yml
+++ b/.github/workflows/baseline.yml
@@ -50,6 +50,6 @@ jobs:
       - name: Use the Upload Artifact GitHub Action
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ needs.generate-name.outputs.v_current_run_timestamp }}_all_CVEs_at_midnight.zip
+          name: ${{ needs.generate-name.outputs.v_current_run_timestamp }}_all_CVEs_at_midnight
           path: ./cves.zip
           overwrite: true


### PR DESCRIPTION
This resolves #67. The root issue is that GitHub's artifact download automatically zips the artifact and append the `.zip` extension to the artifact's name. Using an artifact name ending in `.zip` results in a second `.zip` being appended.