### PR TITLE
fix: use release start timestamp for delta zip filename

### DIFF
--- a/.github/workflows/dist/index.js
+++ b/.github/workflows/dist/index.js
@@ -45291,7 +45291,10 @@ class DeltaCommand extends GenericCommand {
             deltaFs.writeTextFile(`release_notes.md`);
         }
         else {
-            const timestamp = new Date();
+            const releaseTs = process.env.RELEASE_TIMESTAMP;
+            const timestamp = releaseTs
+                ? (() => { const m = releaseTs.match(/^(\d{4}-\d{2}-\d{2})_(\d{2})00Z$/); return m ? new Date(`${m[1]}T${m[2]}:00:00Z`) : new Date(); })()
+                : new Date();
             const delta = await git_Git.newDeltaFromGitHistory(options.start);
             // console.log(`delta=${JSON.stringify(delta, null, 2)}`);
             console.log(delta.toText());

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,8 @@ jobs:
           skip_unpack: true
           if_no_artifact_found: fail
       - name: build delta files
+        env:
+          RELEASE_TIMESTAMP: ${{ needs.generate-name.outputs.v_current_run_timestamp }}
         run: |
           ls ./.github/workflows/dist
           node ./.github/workflows/dist/index.js delta


### PR DESCRIPTION
The delta zip filename was derived from new Date() inside DeltaCommand.run(), which captures the time when the function executes rather than when the release started.

If processing crosses an hour boundary the filename ends up one hour ahead of the release tag (e.g. tag cve_2026-01-29_0200Z contains a file named 2026-01-29_delta_CVEs_at_0300Z.zip).

Fixes #124