### PR TITLE
Improve update github action performance

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -62,10 +62,12 @@ jobs:
           git config --global user.email "github_action@example.com"
           git config --global user.name "cvelistV5 Github Action"
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
-          git pull --ff-only --no-tags
+          export BRANCH="${GITHUB_REF_NAME:-main}"
+          git fetch --quiet --no-tags --depth=1 origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+          git switch --quiet -C "$BRANCH" "origin/$BRANCH"
           export PREV_TS=$(jq -c -r .[2].fetchTime < $CVES_BASE_DIRECTORY/deltaLog.json)
           node ./.github/workflows/dist/index.js update ${{ github.event.inputs.params }} --start=$PREV_TS
-          git push
+          git push --quiet origin "HEAD:${BRANCH}"
       # - name: output
       #   uses: actions/github-script@v6
       #   with:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,6 +29,8 @@ jobs:
   update-cves:
     environment: deployment
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       CVE_SERVICES_URL: https://cveawg.mitre.org
       CVE_SERVICES_RECORDS_PER_PAGE: 500
@@ -45,18 +47,22 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          fetch-tags: false
+          persist-credentials: false
       - name: Setup Node to specific version
         uses: actions/setup-node@v6
         with:
           node-version: 24
       - name: Update CVEs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           export TEMP_TIMESTAMP=$(date '+%Y-%m-%d_%H%M_UTC')
           echo "out=$TEMP_TIMESTAMP" >> $GITHUB_OUTPUT
-          git pull
           git config --global user.email "github_action@example.com"
           git config --global user.name "cvelistV5 Github Action"
-          git remote set-url origin https://${GITHUB_TOKEN}@github.com/${{github.repository}}.git
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          git pull --ff-only --no-tags
           export PREV_TS=$(jq -c -r .[2].fetchTime < $CVES_BASE_DIRECTORY/deltaLog.json)
           node ./.github/workflows/dist/index.js update ${{ github.event.inputs.params }} --start=$PREV_TS
           git push


### PR DESCRIPTION
Since upgrading all of the actions to Node24, the update action has slowed down significantly (from ~2 minutes to ~25 minutes).  This is due in part to some changes in the actions (e.g., actions/checkout), but also to the number of tags and releases this project is keeping.

This update is a first step in fixing that issue.  It was tested in a fork.  It basically prevents the tags and releases from showing up in the fetch, which should solve the main performance problem we've experienced.